### PR TITLE
Support Cabal v3 in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -151,7 +151,11 @@ libraryBuildInfo profile platform@(Platform arch os) ghcVersion = do
     , extraLibs      = extraLibs'
     , extraGHCiLibs  = extraGHCiLibs'
     , extraLibDirs   = extraLibDirs'
-    , options        = [(GHC, ghcOptions) | os /= Windows]
+#if MIN_VERSION_Cabal(3,0,0)
+    , options             = PerCompilerFlavor (if os /= Windows then ghcOptions else []) []
+#else
+    , options             = [(GHC, ghcOptions) | os /= Windows]
+#endif
     , customFieldsBI = [c2hsExtraOptions]
     }
 


### PR DESCRIPTION
This is the same issue as in the [cuda package][0] so I copied the same
fix over.

[0]: https://github.com/tmcdonell/cuda/pull/59

I've only tested this on cabal >= 3.