### PR TITLE
Link to C++ standard libraries.

### DIFF
--- a/cublas.cabal
+++ b/cublas.cabal
@@ -62,6 +62,8 @@ library
     , storable-complex                  >= 0.2
     , template-haskell
 
+  extra-libraries: stdc++
+
   build-tools:
       c2hs                              >= 0.16
 


### PR DESCRIPTION
Cublas (at least more recent versions) includes C++ headers. Executables only succeed build when this library is linked in.

Fixes https://github.com/tmcdonell/cublas/issues/2.